### PR TITLE
Update `crossbeam-utils`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tokio-compat = ["async", "tokio", "async-compat"]
 
 # Dependencies
 [dependencies]
-crossbeam-utils = { version = "0.7", features = ["alloc"], default-features = false }
+crossbeam-utils = { version = "0.8", default-features = false }
 
 [dependencies.async-compat]
 optional = true


### PR DESCRIPTION
I updated `crossbeam-utils` to `0.8.x` to reduce the number of dependencies in my project. The `alloc` feature of this dependency was removed in `0.8.x` as it did nothing.